### PR TITLE
Fix KittenTTS runtime: CPU fallback, cross-platform path, devcontainer model setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,8 @@
   "features": {
     "ghcr.io/devcontainers/features/python:1": {
       "version": "3.12"
-    }
+    },
+    "ghcr.io/devcontainers/features/git-lfs:1": {}
   },
   "customizations": {
     "vscode": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -7,6 +7,13 @@ sudo apt-get update && sudo apt-get install -y espeak-ng
 echo "=== Installing huggingface-hub ==="
 pip install --quiet huggingface-hub
 
+echo "=== Downloading KittenTTS model (if not already present) ==="
+if [ ! -d "models/kittentts" ]; then
+  git clone https://huggingface.co/KittenML/kitten-tts-mini-0.8 models/kittentts
+fi
+# Ensure LFS files are fetched (not just pointers)
+cd models/kittentts && git lfs pull && cd ../..
+
 echo "=== Restoring dependencies ==="
 dotnet restore
 
@@ -17,6 +24,7 @@ echo ""
 echo "=== Setup complete! ==="
 echo ""
 echo "espeak-ng is installed (required for KittenTTS phonemization)."
-echo "huggingface-cli is installed. Download a model, e.g.:"
+echo "KittenTTS model downloaded to models/kittentts/."
+echo "huggingface-cli is installed. Download additional models, e.g.:"
 echo "  huggingface-cli download onnx-community/ast-finetuned-audioset-10-10-0.4593 --include 'onnx/*' --local-dir models/ast"
 echo ""

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -11,8 +11,12 @@ echo "=== Downloading KittenTTS model (if not already present) ==="
 if [ ! -d "models/kittentts" ]; then
   git clone https://huggingface.co/KittenML/kitten-tts-mini-0.8 models/kittentts
 fi
-# Ensure LFS files are fetched (not just pointers)
-cd models/kittentts && git lfs pull && cd ../..
+# Ensure LFS files are fetched (not just pointers) when this is a git repo
+if [ -d "models/kittentts/.git" ]; then
+  cd models/kittentts && git lfs pull && cd ../..
+else
+  echo "models/kittentts exists but is not a git repository; skipping 'git lfs pull'."
+fi
 
 echo "=== Restoring dependencies ==="
 dotnet restore

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -13,4 +13,8 @@
     <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.24.2" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(UseGpuRuntime)' != 'true'">
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.2" />
+  </ItemGroup>
+
 </Project>

--- a/samples/KittenTTS/Program.cs
+++ b/samples/KittenTTS/Program.cs
@@ -42,7 +42,7 @@ using MLNet.AudioInference.Onnx;
 Console.WriteLine("=== KittenTTS Text-to-Speech — ONNX + espeak-ng ===\n");
 
 // --- Resolve model path ---
-var modelDir = args.Length > 0 ? args[0] : @"models\kittentts";
+var modelDir = args.Length > 0 ? args[0] : Path.Combine("models", "kittentts");
 if (!Directory.Exists(modelDir))
 {
     // Also try relative to project directory (for running from repo root via dotnet run --project)


### PR DESCRIPTION
## Summary

Fixes three issues preventing KittenTTS from running in Codespaces / Linux environments.

### Changes

**1. Add CPU native runtime fallback** (`samples/Directory.Build.props`)
The samples `Directory.Build.props` only added `Microsoft.ML.OnnxRuntime.Gpu` when CUDA was detected, but had **no fallback for CPU environments**. This left all non-GPU machines (including Codespaces) without the native `libonnxruntime.so`, causing a `DllNotFoundException` at runtime.

Added:
```xml
<ItemGroup Condition="'$(UseGpuRuntime)' != 'true'">
  <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.2" />
</ItemGroup>
```

The library project (`MLNet.AudioInference.Onnx`) correctly uses `Microsoft.ML.OnnxRuntime.Managed` (API-only) — the consuming application picks the runtime.

**2. Fix cross-platform model path** (`samples/KittenTTS/Program.cs`)
Replaced `@"models\kittentts"` (Windows backslash literal) with `Path.Combine("models", "kittentts")` so the default model path resolves correctly on Linux/macOS.

**3. Add git-lfs to devcontainer** (`.devcontainer/devcontainer.json`)
Added the `ghcr.io/devcontainers/features/git-lfs:1` feature. Required for cloning HuggingFace model repos which use Git LFS for large binary files.

**4. Auto-download KittenTTS model** (`.devcontainer/post-create.sh`)
Added automatic `git clone` + `git lfs pull` for the KittenTTS model in the post-create script so the sample works out-of-the-box after codespace creation.

### Testing

Verified `dotnet run --project samples/KittenTTS/` completes all 4 demo sections successfully on a Linux Codespace.