### PR TITLE
Improve all 9 sample READMEs with troubleshooting, architecture, and pedagogy

### DIFF
--- a/samples/AudioClassification/README.md
+++ b/samples/AudioClassification/README.md
@@ -16,12 +16,14 @@ Audio classification uses a **3-stage ML.NET pipeline** pattern — the same dec
 │   Raw audio → Mel spectrogram (128 bins, 1024 frames)   │
 ├─────────────────────────────────────────────────────────┤
 │ Stage 2: OnnxAudioScoringTransformer                     │
-│   Mel spectrogram → Raw ONNX model output (logits)      │
+│   Mel spectrogram → ONNX Runtime inference → logits      │
 ├─────────────────────────────────────────────────────────┤
 │ Stage 3: AudioClassificationPostProcessingTransformer    │
 │   Logits → Softmax → Labels + Probabilities              │
 └─────────────────────────────────────────────────────────┘
 ```
+
+All three stages implement `ITransformer` (via `IEstimator<T>.Fit()`), which means they compose via ML.NET's lazy pipeline — computation only happens when you iterate the output `IDataView`. This is the same `Fit()`/`Transform()` pattern used across all ML.NET transforms.
 
 The **single-line facade** (`mlContext.Transforms.OnnxAudioClassification(options)`) wires all three stages internally. The **composed pipeline** approach lets you replace or customize any stage — for example, swapping the feature extractor for a different spectrogram configuration.
 

--- a/samples/AudioClassification/README.md
+++ b/samples/AudioClassification/README.md
@@ -326,11 +326,16 @@ huggingface-cli download onnx-community/ast-finetuned-audioset-10-10-0.4593-ONNX
 - Mixed audio (speech over music) may split confidence across multiple labels — this is expected behavior, not an error
 
 ### GPU vs CPU
-The `samples/Directory.Build.props` auto-detects CUDA. If you have a GPU but want CPU inference:
+The `samples/Directory.Build.props` auto-detects CUDA at build/restore time. If you have a GPU but want CPU-only inference, unset the `CUDA_PATH` environment variable before building:
 ```bash
-dotnet run -- "models/ast" "test.wav" --no-gpu
+# PowerShell
+Remove-Item Env:CUDA_PATH -ErrorAction SilentlyContinue
+dotnet run -- "models/ast" "test.wav"
+
+# Bash
+unset CUDA_PATH
+dotnet run -- "models/ast" "test.wav"
 ```
-Or unset the `CUDA_PATH` environment variable before running.
 
 ---
 

--- a/samples/AudioClassification/README.md
+++ b/samples/AudioClassification/README.md
@@ -6,6 +6,27 @@ This sample demonstrates how to classify audio into semantic categories (speech,
 
 How to run an Audio Spectrogram Transformer (AST) model through ML.NET's `IEstimator<T>` / `ITransformer` pattern, and why the pipeline decomposes into three composable stages: feature extraction, scoring, and post-processing.
 
+## Where This Fits in the Architecture
+
+Audio classification uses a **3-stage ML.NET pipeline** pattern — the same decomposition used across all encoder-only transforms in this library:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Stage 1: AudioFeatureExtractionTransformer               │
+│   Raw audio → Mel spectrogram (128 bins, 1024 frames)   │
+├─────────────────────────────────────────────────────────┤
+│ Stage 2: OnnxAudioScoringTransformer                     │
+│   Mel spectrogram → Raw ONNX model output (logits)      │
+├─────────────────────────────────────────────────────────┤
+│ Stage 3: AudioClassificationPostProcessingTransformer    │
+│   Logits → Softmax → Labels + Probabilities              │
+└─────────────────────────────────────────────────────────┘
+```
+
+The **single-line facade** (`mlContext.Transforms.OnnxAudioClassification(options)`) wires all three stages internally. The **composed pipeline** approach lets you replace or customize any stage — for example, swapping the feature extractor for a different spectrogram configuration.
+
+This same 3-stage pattern appears in [AudioEmbeddings](../AudioEmbeddings/) (with pooling instead of softmax) — once you understand one, you understand both.
+
 ---
 
 ## The Concept: Audio Classification
@@ -281,6 +302,33 @@ ML.NET maps between `IDataView` columns and POCO properties using `[ColumnName]`
 3. **Classification outputs are rich.** You get `PredictedLabel` (the answer), `Score` (how confident), and `Probabilities[]` (the full distribution). Use the distribution for multi-label scenarios, confidence thresholds, or debugging.
 
 4. **Three abstraction levels for three use cases.** Facade for simplicity, composed pipeline for flexibility, direct API for minimal ceremony. Same model, same results, different ergonomics.
+
+---
+
+## Troubleshooting
+
+### "Model not found" error
+The AST ONNX model must be downloaded separately. The `onnx/` subdirectory should contain `model.onnx`:
+```bash
+huggingface-cli download onnx-community/ast-finetuned-audioset-10-10-0.4593-ONNX --include "onnx/*" --local-dir models/ast
+```
+
+### Audio file format issues
+- The sample auto-resamples to 16kHz — most formats work
+- If you get garbled results, ensure your WAV file is valid PCM (not compressed)
+- Very short audio (<0.5s) may not produce meaningful classification results
+
+### Unexpected labels or low confidence
+- AST was trained on AudioSet — it recognizes ~527 labels but the sample shows a 20-class subset
+- Very quiet audio may classify as "Silence" even if it contains faint sounds
+- Mixed audio (speech over music) may split confidence across multiple labels — this is expected behavior, not an error
+
+### GPU vs CPU
+The `samples/Directory.Build.props` auto-detects CUDA. If you have a GPU but want CPU inference:
+```bash
+dotnet run -- "models/ast" "test.wav" --no-gpu
+```
+Or unset the `CUDA_PATH` environment variable before running.
 
 ---
 

--- a/samples/AudioDataIngestion/README.md
+++ b/samples/AudioDataIngestion/README.md
@@ -321,6 +321,8 @@ var results = allChunks
 
 This is the retrieval phase of audio RAG. In production, you'd store embeddings in a vector database (e.g., Qdrant, Pinecone, Azure AI Search) and query it, but the similarity math is the same.
 
+> **Under the hood**: The similarity search uses `TensorPrimitives.CosineSimilarity()` from `System.Numerics.Tensors` — .NET's SIMD-accelerated vector math API. This is the same API used in text embedding pipelines, reinforcing the modality-agnostic design: audio embeddings are just float arrays, and vector operations work identically regardless of what produced them.
+
 ### Synthetic Audio Patterns
 
 The four test signals are deliberately chosen to create meaningful similarity structure:

--- a/samples/AudioDataIngestion/README.md
+++ b/samples/AudioDataIngestion/README.md
@@ -34,6 +34,18 @@ This was designed for text workflows — reading Markdown, PDF, or HTML, chunkin
 
 The key insight: **`T` is generic**. When `T = AudioData`, each `IngestionChunk<AudioData>` carries the actual audio segment as its content — type-safe, no serialization hacks, and directly consumable by the embedding generator.
 
+### The Key Insight: Modality-Agnostic Pipelines
+
+The `Microsoft.Extensions.DataIngestion` library was designed for text documents (PDFs, markdown, web pages), but its abstractions are **fundamentally modality-agnostic**:
+
+| Text Pipeline | Audio Pipeline | Shared Abstraction |
+|---|---|---|
+| `MarkdownReader` | `AudioDocumentReader` | `IngestionDocumentReader` |
+| `HeaderChunker` | `AudioSegmentChunker` | `IngestionChunker<T>` |
+| `TextEmbeddingProcessor` | `AudioEmbeddingChunkProcessor` | `IngestionChunkProcessor<T>` |
+
+This means you can mix modalities in the same pipeline, use the same vector store infrastructure, and leverage the same DI registration patterns — regardless of whether your content is text, audio, images, or video.
+
 ### Why This Matters for RAG
 
 Audio files — podcasts, meetings, music libraries, voice recordings — need to be searchable too. The RAG pattern for audio is:
@@ -329,6 +341,30 @@ Expected similarity ordering: `440 Hz ↔ 880 Hz > 440 Hz ↔ chirp > 440 Hz ↔
 3. **`IAsyncEnumerable` streaming enables memory-efficient processing.** Large audio collections (thousands of files, hours of audio) can be processed chunk-by-chunk without loading everything into memory. Each chunk flows through the pipeline and can be indexed incrementally.
 
 4. **This enables audio RAG.** Index audio libraries by embedding, search by acoustic similarity, retrieve relevant segments. The same vector-store infrastructure used for text RAG works for audio — because the embeddings are just `float[]` vectors regardless of modality.
+
+## Troubleshooting
+
+### "Model not found" — synthetic demo runs instead
+This is expected behavior, not an error. Without a CLAP model, the sample demonstrates the pipeline components (Reader, Chunker) with synthetic data. To run with real embeddings:
+```bash
+huggingface-cli download lquint/clap-htsat-unfused-onnx --local-dir models/clap
+```
+
+### Cosine similarity values seem wrong
+- Identical audio should have similarity ~1.0, completely different audio ~0.0
+- If all similarities are very high (>0.95), the model may not be discriminating well — try longer audio segments
+- If all similarities are near 0, check that the embedding dimension matches your model's output
+
+### Memory issues with large audio files
+The DataIngestion pipeline processes audio in chunks (default 2-second segments). If you're running out of memory:
+- Reduce segment size: `new AudioSegmentChunker(TimeSpan.FromSeconds(1))`
+- Process files one at a time instead of loading all into memory
+- The pipeline uses `IAsyncEnumerable` — memory usage should be bounded by chunk count, not file size
+
+### Audio file not recognized
+- Only WAV format is supported by `AudioDocumentReader`
+- The reader expects PCM WAV (uncompressed). Compressed formats (MP3, FLAC, OGG) need conversion first
+- Use ffmpeg to convert: `ffmpeg -i input.mp3 -ar 16000 -ac 1 output.wav`
 
 ## Going Further
 

--- a/samples/AudioEmbeddings/README.md
+++ b/samples/AudioEmbeddings/README.md
@@ -21,9 +21,6 @@ Audio embeddings sit at the **intersection of three abstraction layers**:
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│ Layer 3: DataIngestion                                    │
-│   AudioEmbeddingChunkProcessor uses embeddings for RAG   │
-├─────────────────────────────────────────────────────────┤
 │ Layer 2: MEAI (Microsoft.Extensions.AI)                  │
 │   IEmbeddingGenerator<AudioData, Embedding<float>>       │
 ├─────────────────────────────────────────────────────────┤
@@ -35,7 +32,7 @@ Audio embeddings sit at the **intersection of three abstraction layers**:
 └─────────────────────────────────────────────────────────┘
 ```
 
-This sample demonstrates Layers 0-2. The [AudioDataIngestion](../AudioDataIngestion/) sample shows how Layer 3 builds on top of these embeddings for full RAG pipelines.
+The [AudioDataIngestion](../AudioDataIngestion/) sample shows how Layer 3 (Microsoft.Extensions.DataIngestion) builds on top of these embeddings for full RAG pipelines.
 
 ---
 
@@ -100,6 +97,8 @@ Once you have two embedding vectors, you measure their closeness with **cosine s
 | **-1.0** | Opposite direction → maximally dissimilar |
 
 When embeddings are L2-normalized (as this sample does by default), cosine similarity simplifies to the dot product, which is extremely fast.
+
+> **Under the hood**, similarity is computed using `TensorPrimitives.CosineSimilarity()` from `System.Numerics.Tensors` — a SIMD-accelerated vector math API that makes these comparisons efficient even at scale.
 
 ### The Model: CLAP
 

--- a/samples/AudioEmbeddings/README.md
+++ b/samples/AudioEmbeddings/README.md
@@ -15,6 +15,30 @@ This sample demonstrates how to generate **vector embeddings** from audio using 
 
 ---
 
+## Where This Fits in the Architecture
+
+Audio embeddings sit at the **intersection of three abstraction layers**:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Layer 3: DataIngestion                                    │
+│   AudioEmbeddingChunkProcessor uses embeddings for RAG   │
+├─────────────────────────────────────────────────────────┤
+│ Layer 2: MEAI (Microsoft.Extensions.AI)                  │
+│   IEmbeddingGenerator<AudioData, Embedding<float>>       │
+├─────────────────────────────────────────────────────────┤
+│ Layer 1: ML.NET Pipeline (3-stage decomposition)         │
+│   Feature Extraction → ONNX Scoring → Embedding Pooling  │
+├─────────────────────────────────────────────────────────┤
+│ Layer 0: Audio Primitives                                 │
+│   AudioData, MelSpectrogramExtractor, AudioIO            │
+└─────────────────────────────────────────────────────────┘
+```
+
+This sample demonstrates Layers 0-2. The [AudioDataIngestion](../AudioDataIngestion/) sample shows how Layer 3 builds on top of these embeddings for full RAG pipelines.
+
+---
+
 ## The Concept: Audio Embeddings
 
 ### What Is an Embedding?
@@ -311,6 +335,31 @@ Because `OnnxAudioEmbeddingGenerator` implements `IDisposable`, the `using` decl
 3. **`TensorPrimitives` provides SIMD-accelerated math primitives** — use `TensorPrimitives.CosineSimilarity`, `TensorPrimitives.Dot`, `TensorPrimitives.Normalize`, etc. instead of hand-rolling vector math. They're faster and correct.
 
 4. **MEAI makes the embedding generator pluggable and DI-friendly** — wrapping in `IEmbeddingGenerator<AudioData, Embedding<float>>` means you can swap providers, add middleware (caching, logging, rate-limiting), and inject the generator wherever it's needed — all without changing consuming code.
+
+---
+
+## Troubleshooting
+
+### "Model not found" — synthetic demo runs instead
+This is expected behavior. Without a CLAP model, the sample demonstrates AudioData primitives and mel spectrogram extraction. To run with real embeddings:
+```bash
+huggingface-cli download lquint/clap-htsat-unfused-onnx --local-dir models/clap
+```
+
+### All embeddings look the same (high cosine similarity)
+- Ensure test audio files are genuinely different (e.g., speech vs music vs silence)
+- Very short audio (<1s) may not give the model enough information to discriminate
+- Check pooling strategy — `MeanPooling` averages across all frames; `ClsToken` uses just the first frame's representation
+
+### Embedding dimension doesn't match expected
+Different models produce different embedding sizes:
+- CLAP: 512 dimensions
+- Wav2Vec2: 768 dimensions
+- HuBERT: 768 or 1024 dimensions
+The `OnnxAudioEmbeddingTransformer` auto-detects the hidden dimension from the ONNX model's output shape.
+
+### GPU out of memory
+Audio embeddings require less memory than training, but large batches can still OOM. Process one file at a time or reduce audio duration. The `samples/Directory.Build.props` auto-detects CUDA — unset `CUDA_PATH` to force CPU.
 
 ---
 

--- a/samples/KittenTTS/README.md
+++ b/samples/KittenTTS/README.md
@@ -16,7 +16,8 @@ KittenTTS takes a fundamentally different approach from SpeechT5:
 | Aspect | SpeechT5 | KittenTTS |
 |--------|----------|-----------|
 | ONNX models | 3 (encoder + decoder + vocoder) | 1 (single-pass) |
-| Tokenization | SentencePiece (character-level) | espeak-ng IPA phonemes → token IDs |
+| Tokenization | SentencePiece (character-level) | KittenTtsTokenizer (ML.Tokenizers) — 176-symbol IPA vocabulary |
+| Text processing | Built-in encoder | MEDI pipeline: TtsSentenceChunker → EspeakPhonemizationProcessor |
 | Decoding | Autoregressive with KV cache | Single forward pass |
 | Voice mechanism | External speaker embedding (float[]) | NPZ voice archive with named voices |
 | Output sample rate | 16 kHz | 24 kHz |
@@ -26,11 +27,14 @@ KittenTTS takes a fundamentally different approach from SpeechT5:
 
 ```
 "Hello world!"
-    ↓ Text chunking (max 400 chars, sentence boundaries)
-    ↓ Phonemization via espeak-ng (IPA with stress marks)
-    ↓ TextCleaner (IPA symbols → integer token IDs)
-    ↓ Single ONNX model (token IDs + voice embedding + speed → waveform)
-    ↓ Trim trailing samples, concatenate chunks
+    ↓ TtsSentenceChunker (MEDI IngestionChunker<string>)
+    │   Splits at sentence boundaries [.!?], token-aware sizing
+    ↓ EspeakPhonemizationProcessor (MEDI IngestionChunkProcessor<string>)
+    │   English text → IPA phonemes via espeak-ng subprocess
+    ↓ KittenTtsTokenizer (Microsoft.ML.Tokenizers.Tokenizer)
+    │   IPA characters → integer token IDs (176-symbol vocabulary)
+    ↓ Single ONNX model
+    │   Token IDs + voice embedding + speed → raw PCM waveform
     → AudioData at 24 kHz
 ```
 
@@ -39,6 +43,78 @@ KittenTTS takes a fundamentally different approach from SpeechT5:
 KittenTTS ships with **8 built-in voices**: Bella, Jasper, Luna, Bruno, Rosie, Hugo, Kiki, Leo.
 
 Voice embeddings are stored in `voices.npz` (a NumPy compressed ZIP archive). The transformer reads this file natively using a built-in NPZ/NPY parser — no Python required.
+
+### Understanding Phonemes and IPA
+
+If you've ever noticed that "read" (present) and "read" (past) are spelled identically but sound different, you've discovered why TTS models can't just feed raw text to a neural network. English spelling is famously inconsistent:
+
+| Word pair | Same spelling? | Same sound? |
+|-----------|---------------|-------------|
+| read (present) / read (past) | ✅ | ❌ (/ɹiːd/ vs /ɹɛd/) |
+| lead (verb) / lead (noun) | ✅ | ❌ (/liːd/ vs /lɛd/) |
+| through / though / thought | Similar | ❌ (all different vowels) |
+
+**Phonemes** are the actual sounds of speech — the building blocks that distinguish one word from another. The **International Phonetic Alphabet (IPA)** provides a universal notation where each symbol maps to exactly one sound, regardless of language or spelling.
+
+For example, "Hello world" becomes:
+
+```
+"Hello world" → /həˈloʊ wɜːld/
+
+h  → voiceless glottal fricative (the breathy "h")
+ə  → schwa (unstressed vowel, like "a" in "about")
+ˈ  → primary stress marker (next syllable is emphasized)
+l  → lateral approximant (tongue touches roof of mouth)
+oʊ → diphthong (the "oh" sound glides from o to ʊ)
+w  → labial-velar approximant (the "w" sound)
+ɜː → open-mid central vowel (the "ur" in "world")
+l  → lateral approximant again
+d  → voiced alveolar plosive (the "d" sound)
+```
+
+**espeak-ng** is the industry-standard open-source phonemizer. It handles all the ambiguities of English spelling — stress placement, silent letters, irregular pronunciations — and produces clean IPA output.
+
+KittenTTS uses **176 IPA symbols** in its vocabulary: 1 pad symbol, 11 punctuation marks, 52 ASCII letters, and 112 IPA extension characters. Each IPA character maps to exactly one integer token ID via `KittenTtsTokenizer`.
+
+> **How is this different from SpeechT5?** SpeechT5 uses SentencePiece character-level tokenization — it feeds raw letters to the model and lets the encoder learn pronunciation implicitly. KittenTTS makes pronunciation *explicit* via phonemization, which gives the model cleaner input at the cost of requiring espeak-ng as an external dependency.
+
+### How the Abstraction Layers Compose
+
+KittenTTS is built from four layers, each using standard .NET abstractions:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Layer 3: Microsoft.Extensions.DataIngestion (MEDI)      │
+│   TtsSentenceChunker → EspeakPhonemizationProcessor     │
+├─────────────────────────────────────────────────────────┤
+│ Layer 2: Microsoft.ML.Tokenizers                        │
+│   KittenTtsTokenizer (Tokenizer base class)             │
+├─────────────────────────────────────────────────────────┤
+│ Layer 1: ML.NET Custom Transforms                       │
+│   OnnxKittenTtsTransformer (ITransformer)               │
+├─────────────────────────────────────────────────────────┤
+│ Layer 0: ONNX Runtime                                   │
+│   Single-pass neural network inference                  │
+└─────────────────────────────────────────────────────────┘
+```
+
+This layered design isn't accidental — each layer aligns with a real .NET ecosystem abstraction:
+
+- **Composability** — `TtsSentenceChunker` and `EspeakPhonemizationProcessor` implement MEDI's `IngestionChunker<string>` and `IngestionChunkProcessor<string>`. They can be used independently or plugged into any pipeline that works with MEDI abstractions.
+- **Ecosystem alignment** — the same `IngestionChunker<string>` abstraction that chunks documents for text RAG also chunks text for TTS. If you've used MEDI for search indexing, the chunking model is already familiar.
+- **Swappability** — the transformer constructor accepts any `Microsoft.ML.Tokenizers.Tokenizer` via `options.Tokenizer`. Want a custom IPA tokenizer with a different symbol set? Provide it — the pipeline doesn't care.
+- **Token-aware chunking** — instead of splitting at a fixed character count, `TtsSentenceChunker` accepts a `Func<string, int> measureLength` parameter. KittenTTS passes `tokenizer.CountTokens`, so chunks are measured in *tokens*, not characters. This matters because IPA symbols like `oʊ` are two Unicode characters but one token.
+
+Here's how the transformer wires these layers together:
+
+```csharp
+// In OnnxKittenTtsTransformer constructor:
+_tokenizer = options.Tokenizer ?? KittenTtsTokenizer.Create();
+_phonemizer = new EspeakPhonemizationProcessor(options.EspeakPath);
+_chunker = new TtsSentenceChunker(
+    maxLengthPerChunk: options.MaxTokensPerChunk ?? options.MaxChunkLength,
+    measureLength: s => _tokenizer.CountTokens(s));
+```
 
 ## About KittenTTS
 
@@ -53,7 +129,7 @@ Traditional TTS (like SpeechT5) works in stages:
 2. Decode hidden states → mel spectrogram (one frame at a time, autoregressively)
 3. Vocoder converts mel → PCM waveform
 
-KittenTTS collapses all of this into **one model** that takes phoneme token IDs and outputs raw audio directly. The trade-off: it's simpler and faster, but has a fixed maximum input length (handled via chunking at 400 characters).
+KittenTTS collapses all of this into **one model** that takes phoneme token IDs and outputs raw audio directly. The trade-off: it's simpler and faster, but has a fixed maximum input length (handled via token-aware chunking using Microsoft.Extensions.DataIngestion's `IngestionChunker` abstraction).
 
 ### What Problems It Solves
 
@@ -209,7 +285,7 @@ Without a model, the sample prints download instructions and API pattern example
 - **English only** — KittenTTS is trained on English speech data. Other languages will produce garbled output or errors from espeak-ng phonemization.
 - **Fixed voice set** — unlike SpeechT5 which supports custom speaker embeddings for voice cloning, KittenTTS only supports its 8 built-in voices.
 - **Requires espeak-ng** — the external `espeak-ng` tool must be installed and on PATH for phonemization. This is an extra setup step compared to SpeechT5 which handles tokenization internally.
-- **Chunk boundary artifacts** — very long text is split into 400-character chunks. Audio quality may degrade slightly at chunk boundaries.
+- **Chunk boundary artifacts** — very long text is split into token-based chunks (default 400 tokens). Audio quality may degrade slightly at chunk boundaries.
 - **Model variant differences** — voice names and ONNX filenames differ between model sizes (mini/micro/nano). The transformer auto-detects and falls back gracefully, but the mini model's voice names (Bella, Jasper, etc.) are the canonical ones.
 - **No streaming** — the ONNX model generates the full waveform in one pass. There's no incremental audio output during generation.
 
@@ -264,5 +340,7 @@ dotnet run --project samples/KittenTTS -- "C:\full\path\to\models\kittentts"
 |---|---|
 | [`samples/TextToSpeech`](../TextToSpeech/) | SpeechT5 TTS — 3-model encoder-decoder-vocoder pipeline |
 | [`samples/SpeechToText`](../SpeechToText/) | ASR via ISpeechToTextClient — round-trip partner for TTS |
+| [`src/MLNet.Audio.DataIngestion`](../../src/MLNet.Audio.DataIngestion/) | TtsSentenceChunker, EspeakPhonemizationProcessor — the MEDI components used by KittenTTS |
+| [`src/MLNet.Audio.Tokenizers`](../../src/MLNet.Audio.Tokenizers/) | KittenTtsTokenizer — the ML.Tokenizers IPA tokenizer |
 | [`docs/architecture.md`](../../docs/architecture.md) | Full system architecture and TTS pipeline details |
 | [`docs/meai-integration.md`](../../docs/meai-integration.md) | MEAI interface mapping including ITextToSpeechClient |

--- a/samples/KittenTTS/README.md
+++ b/samples/KittenTTS/README.md
@@ -110,7 +110,7 @@ This layered design isn't accidental — each layer aligns with a real .NET ecos
 - **Composability** — `TtsSentenceChunker` and `EspeakPhonemizationProcessor` implement MEDI's `IngestionChunker<string>` and `IngestionChunkProcessor<string>`. They can be used independently or plugged into any pipeline that works with MEDI abstractions.
 - **Ecosystem alignment** — the same `IngestionChunker<string>` abstraction that chunks documents for text RAG also chunks text for TTS. If you've used MEDI for search indexing, the chunking model is already familiar.
 - **Swappability** — the transformer constructor accepts any `Microsoft.ML.Tokenizers.Tokenizer` via `options.Tokenizer`. Want a custom IPA tokenizer with a different symbol set? Provide it — the pipeline doesn't care.
-- **Token-aware chunking** — instead of splitting at a fixed character count, `TtsSentenceChunker` accepts a `Func<string, int> measureLength` parameter. KittenTTS passes `tokenizer.CountTokens`, so chunks are measured in *tokens*, not characters. This matters because IPA symbols like `oʊ` are two Unicode characters but one token.
+- **Token-aware chunking** — instead of splitting at a fixed character count, `TtsSentenceChunker` accepts a `Func<string, int> measureLength` parameter. KittenTTS passes `tokenizer.CountTokens`, so chunk sizes reflect what the model actually sees — unknown characters (those outside the 176-symbol IPA vocabulary) are silently skipped and don't count toward the limit, giving a more accurate measure than raw `string.Length`.
 
 Here's how the transformer wires these layers together:
 
@@ -292,7 +292,7 @@ Without a model, the sample prints download instructions and API pattern example
 - **English only** — KittenTTS is trained on English speech data. Other languages will produce garbled output or errors from espeak-ng phonemization.
 - **Fixed voice set** — unlike SpeechT5 which supports custom speaker embeddings for voice cloning, KittenTTS only supports its 8 built-in voices.
 - **Requires espeak-ng** — the external `espeak-ng` tool must be installed and on PATH for phonemization. This is an extra setup step compared to SpeechT5 which handles tokenization internally.
-- **Chunk boundary artifacts** — very long text is split into token-based chunks (default 400 tokens). Audio quality may degrade slightly at chunk boundaries.
+- **Chunk boundary artifacts** — very long text is split into chunks for processing. By default, the chunk limit is 400 (via `MaxChunkLength` for backward compatibility). The chunker measures length using `tokenizer.CountTokens`, which for KittenTTS's character-level tokenizer is close to character count but skips unknown symbols. To set an explicit token-based limit, use `MaxTokensPerChunk` in `OnnxKittenTtsOptions`. Audio quality may degrade slightly at chunk boundaries.
 - **Model variant differences** — voice names and ONNX filenames differ between model sizes (mini/micro/nano). The transformer auto-detects and falls back gracefully, but the mini model's voice names (Bella, Jasper, etc.) are the canonical ones.
 - **No streaming** — the ONNX model generates the full waveform in one pass. There's no incremental audio output during generation.
 

--- a/samples/KittenTTS/README.md
+++ b/samples/KittenTTS/README.md
@@ -94,8 +94,9 @@ KittenTTS is built from five layers, each using standard .NET abstractions:
 │   ITextToSpeechClient → OnnxTextToSpeechClient          │
 │   (Same interface for KittenTTS, SpeechT5, or cloud)    │
 ├─────────────────────────────────────────────────────────┤
-│ Layer 1: ML.NET Custom Transforms                       │
-│   OnnxKittenTtsTransformer : IOnnxTtsSynthesizer        │
+│ Layer 1: ML.NET Custom Transforms (IEstimator/ITransformer)│
+│   OnnxKittenTtsTransformer : ITransformer, IOnnxTtsSynthesizer
+│   Enables .Fit() / .Transform() pipeline composition     │
 ├─────────────────────────────────────────────────────────┤
 │ Layer 0: ONNX Runtime                                   │
 │   Single-pass neural network inference                  │
@@ -104,6 +105,7 @@ KittenTTS is built from five layers, each using standard .NET abstractions:
 
 This layered design isn't accidental — each layer aligns with a real .NET ecosystem abstraction:
 
+- **Pipeline composition** — `OnnxKittenTtsTransformer` implements ML.NET's `ITransformer` interface, which means it plugs into the standard `.Fit()` / `.Transform()` pipeline. You can compose it with other transforms (e.g., text preprocessing → TTS → audio post-processing) using `mlContext.Transforms.KittenTts(options)`. The `IEstimator<T>` pattern separates configuration (estimator) from execution (transformer) — `.Fit()` creates the transformer, `.Transform()` runs inference.
 - **Provider abstraction** — `ITextToSpeechClient` from Microsoft.Extensions.AI means your consuming code doesn't know or care whether KittenTTS, SpeechT5, Azure Speech, or OpenAI is doing the synthesis. `OnnxTextToSpeechClient` wraps any `IOnnxTtsSynthesizer` — swap from KittenTTS to SpeechT5 with a one-line options change. This is the same pattern used for `ISpeechToTextClient` in the ASR samples.
 - **Composability** — `TtsSentenceChunker` and `EspeakPhonemizationProcessor` implement MEDI's `IngestionChunker<string>` and `IngestionChunkProcessor<string>`. They can be used independently or plugged into any pipeline that works with MEDI abstractions.
 - **Ecosystem alignment** — the same `IngestionChunker<string>` abstraction that chunks documents for text RAG also chunks text for TTS. If you've used MEDI for search indexing, the chunking model is already familiar.

--- a/samples/KittenTTS/README.md
+++ b/samples/KittenTTS/README.md
@@ -80,18 +80,22 @@ KittenTTS uses **176 IPA symbols** in its vocabulary: 1 pad symbol, 11 punctuati
 
 ### How the Abstraction Layers Compose
 
-KittenTTS is built from four layers, each using standard .NET abstractions:
+KittenTTS is built from five layers, each using standard .NET abstractions:
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│ Layer 3: Microsoft.Extensions.DataIngestion (MEDI)      │
+│ Layer 4: Microsoft.Extensions.DataIngestion (MEDI)      │
 │   TtsSentenceChunker → EspeakPhonemizationProcessor     │
 ├─────────────────────────────────────────────────────────┤
-│ Layer 2: Microsoft.ML.Tokenizers                        │
+│ Layer 3: Microsoft.ML.Tokenizers                        │
 │   KittenTtsTokenizer (Tokenizer base class)             │
 ├─────────────────────────────────────────────────────────┤
+│ Layer 2: Microsoft.Extensions.AI (MEAI)                 │
+│   ITextToSpeechClient → OnnxTextToSpeechClient          │
+│   (Same interface for KittenTTS, SpeechT5, or cloud)    │
+├─────────────────────────────────────────────────────────┤
 │ Layer 1: ML.NET Custom Transforms                       │
-│   OnnxKittenTtsTransformer (ITransformer)               │
+│   OnnxKittenTtsTransformer : IOnnxTtsSynthesizer        │
 ├─────────────────────────────────────────────────────────┤
 │ Layer 0: ONNX Runtime                                   │
 │   Single-pass neural network inference                  │
@@ -100,6 +104,7 @@ KittenTTS is built from four layers, each using standard .NET abstractions:
 
 This layered design isn't accidental — each layer aligns with a real .NET ecosystem abstraction:
 
+- **Provider abstraction** — `ITextToSpeechClient` from Microsoft.Extensions.AI means your consuming code doesn't know or care whether KittenTTS, SpeechT5, Azure Speech, or OpenAI is doing the synthesis. `OnnxTextToSpeechClient` wraps any `IOnnxTtsSynthesizer` — swap from KittenTTS to SpeechT5 with a one-line options change. This is the same pattern used for `ISpeechToTextClient` in the ASR samples.
 - **Composability** — `TtsSentenceChunker` and `EspeakPhonemizationProcessor` implement MEDI's `IngestionChunker<string>` and `IngestionChunkProcessor<string>`. They can be used independently or plugged into any pipeline that works with MEDI abstractions.
 - **Ecosystem alignment** — the same `IngestionChunker<string>` abstraction that chunks documents for text RAG also chunks text for TTS. If you've used MEDI for search indexing, the chunking model is already familiar.
 - **Swappability** — the transformer constructor accepts any `Microsoft.ML.Tokenizers.Tokenizer` via `options.Tokenizer`. Want a custom IPA tokenizer with a different symbol set? Provide it — the pipeline doesn't care.

--- a/samples/SpeechToText/README.md
+++ b/samples/SpeechToText/README.md
@@ -225,6 +225,8 @@ This sample sits at the **highest abstraction level**. Here's how the three appr
 | **Best for** | Production pipelines | Easy local inference | Custom decoding, research |
 | **Cloud support?** | ✅ Azure, OpenAI, etc. | ❌ Local only | ❌ Local only |
 
+**The key insight:** all three approaches can be consumed through the same `ISpeechToTextClient` interface. `OnnxSpeechToTextClient` wraps ORT GenAI, `OnnxWhisperSpeechToTextClient` wraps raw ONNX — your pipeline code stays identical regardless of which backend you choose.
+
 ## Key Takeaways
 
 1. **Provider abstraction is the most important pattern for production systems.** Write your pipeline once against `ISpeechToTextClient`, then swap Azure → OpenAI → local Whisper → a mock without changing pipeline code.
@@ -244,6 +246,18 @@ This sample sits at the **highest abstraction level**. Here's how the three appr
 | [TextToSpeech](../TextToSpeech/) | The reverse direction — text → audio via SpeechT5 ONNX, completing the voice round-trip |
 | [docs/meai-integration.md](../../docs/meai-integration.md) | Deep dive into the Microsoft.Extensions.AI integration patterns (`ISpeechToTextClient`, `IEmbeddingGenerator<AudioData, Embedding<float>>`) |
 
+## Prerequisites
+
+### Required Software
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download)
+
+### No Model Required
+
+This sample is **purely demonstrative** — it shows API patterns and architecture without requiring any ONNX model or external service. It generates synthetic audio for feature extraction demonstrations.
+
+This is intentional: the sample teaches you the **patterns** for provider-agnostic speech-to-text so you can plug in any backend (Azure Speech, OpenAI Whisper API, local Whisper model, or a mock for testing).
+
 ## Running the Sample
 
 ```bash
@@ -252,3 +266,23 @@ dotnet run
 ```
 
 No model downloads or API keys required — the sample demonstrates patterns and runs real feature extraction on synthetic audio.
+
+## Troubleshooting
+
+### "No actual transcription happens"
+This is by design. The SpeechToText sample demonstrates **patterns and architecture**, not actual inference. For real transcription:
+- **Easiest**: Use the [WhisperTranscription](../WhisperTranscription/) sample with an ORT GenAI Whisper model
+- **Most control**: Use the [WhisperRawOnnx](../WhisperRawOnnx/) sample with raw ONNX encoder/decoder models
+- **Cloud**: Implement `ISpeechToTextClient` against Azure Speech Services or OpenAI Whisper API
+
+### Which ISpeechToTextClient implementation should I use?
+
+| Approach | Best For | Complexity | Latency |
+|----------|----------|------------|---------|
+| Cloud provider (Azure, OpenAI) | Production, highest accuracy | Low (API key) | Network-dependent |
+| ORT GenAI (`OnnxSpeechToTextClient`) | Local inference, simple API | Medium (model download) | ~2-5s for 30s audio |
+| Raw ONNX (`OnnxWhisperSpeechToTextClient`) | Full control, custom sampling | High (manual KV cache) | ~2-5s for 30s audio |
+| Mock client | Unit testing | Trivial | Instant |
+
+### Build warnings about missing ONNX models
+Some warnings about ONNX model paths are expected in this sample since no model is loaded. The sample runs successfully without any models.

--- a/samples/TextToSpeech/README.md
+++ b/samples/TextToSpeech/README.md
@@ -361,7 +361,7 @@ git clone https://huggingface.co/NeuML/txtai-speecht5-onnx models/speecht5
 
 ### Output sounds garbled or robotic
 - Verify all three ONNX files downloaded completely (check file sizes above)
-- Ensure `spm_char.model` is present — without the tokenizer, text encoding fails silently
+- Ensure `spm_char.model` is present — if the tokenizer file is missing, SpeechT5 will throw a file-not-found exception when loading
 - Very long text may accumulate decoder errors. Try shorter sentences first
 - The stop threshold (0.5) may cause early cutoff for some voices — try lowering to 0.3
 

--- a/samples/TextToSpeech/README.md
+++ b/samples/TextToSpeech/README.md
@@ -8,6 +8,30 @@
 - **`ITextToSpeechClient`** — the official MEAI interface for TTS, backed by local ONNX models
 - **Whisper ↔ SpeechT5 symmetry** — how ASR and TTS are mirror-image pipelines sharing the same KV cache pattern
 
+## Where This Fits in the Architecture
+
+SpeechT5 is the most complex transform in the library — a **3-model autoregressive pipeline**:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Layer 2: MEAI                                            │
+│   ITextToSpeechClient (same interface for SpeechT5 AND  │
+│   KittenTTS — swap backends without changing your code)  │
+├─────────────────────────────────────────────────────────┤
+│ Layer 1: ML.NET Transform                                │
+│   OnnxSpeechT5TtsTransformer (ITransformer)              │
+│   ├─ SentencePieceCharTokenizer (ML.Tokenizers)         │
+│   ├─ ONNX Encoder → hidden states                        │
+│   ├─ ONNX Decoder (autoregressive + KV cache) → mel     │
+│   └─ ONNX Vocoder (HiFi-GAN) → PCM waveform            │
+├─────────────────────────────────────────────────────────┤
+│ Layer 0: Audio Primitives                                 │
+│   AudioData, AudioIO (WAV I/O)                           │
+└─────────────────────────────────────────────────────────┘
+```
+
+The `ITextToSpeechClient` abstraction means you can switch from SpeechT5 to [KittenTTS](../KittenTTS/) (or a cloud API) with a single line change. The [KittenTTS sample](../KittenTTS/) shows the lightweight alternative.
+
 ## The Concept: Text-to-Speech Synthesis
 
 ### What TTS Is
@@ -316,6 +340,51 @@ This creates an audio-to-audio pipeline: input audio is transcribed by Whisper, 
 3. **`ITextToSpeechClient` is the official MEAI interface.** Available in `Microsoft.Extensions.AI.Abstractions` 10.4.1 (marked `[Experimental]`). `OnnxTextToSpeechClient` accepts both `OnnxSpeechT5Options` and `OnnxKittenTtsOptions` — one client for all local TTS backends via the internal `IOnnxTtsSynthesizer` interface.
 
 4. **Whisper and SpeechT5 are mirrors.** Same KV cache autoregressive pattern, opposite direction. Understanding one helps you understand the other. The key insight: both models generate output *one step at a time*, feeding each output back as input to the next step.
+
+## Troubleshooting
+
+### "Model not found" errors
+SpeechT5 requires **three** separate ONNX files. Verify all are present:
+```bash
+ls models/speecht5/
+# Should contain:
+#   encoder_model.onnx           (~343 MB)
+#   decoder_model_merged.onnx    (~244 MB)
+#   decoder_postnet_and_vocoder.onnx (~55 MB)
+#   spm_char.model               (SentencePiece tokenizer)
+#   speaker.npy                  (default speaker embedding)
+```
+Download with:
+```bash
+git clone https://huggingface.co/NeuML/txtai-speecht5-onnx models/speecht5
+```
+
+### Output sounds garbled or robotic
+- Verify all three ONNX files downloaded completely (check file sizes above)
+- Ensure `spm_char.model` is present — without the tokenizer, text encoding fails silently
+- Very long text may accumulate decoder errors. Try shorter sentences first
+- The stop threshold (0.5) may cause early cutoff for some voices — try lowering to 0.3
+
+### Output is silent (0-length audio)
+- The autoregressive decoder may not have converged. This can happen with:
+  - Empty or whitespace-only input text
+  - Characters not in the SentencePiece vocabulary
+  - Corrupted model files (re-download)
+
+### Comparing with KittenTTS
+If you're choosing between SpeechT5 and KittenTTS:
+
+| Criterion | SpeechT5 | KittenTTS |
+|-----------|----------|-----------|
+| Quality | Good, natural prosody | Good, natural prosody |
+| Speed | Slower (autoregressive decoder loop) | Faster (single forward pass) |
+| Model size | ~642 MB (3 files) | 41-80 MB (1 file) |
+| Voices | Custom via speaker embedding | 8 built-in (Bella, Jasper, etc.) |
+| Voice cloning | ✅ Any x-vector embedding | ❌ Fixed voice set |
+| External deps | None | Requires espeak-ng |
+| Output quality | 16 kHz | 24 kHz |
+
+**Recommendation**: Use KittenTTS for quick prototyping and lightweight deployment. Use SpeechT5 when you need voice cloning or don't want external dependencies.
 
 ## Going Further
 

--- a/samples/VoiceActivityDetection/README.md
+++ b/samples/VoiceActivityDetection/README.md
@@ -107,6 +107,27 @@ Audio stream
   SpeechSegment[] (Start, End, Confidence)
 ```
 
+### Abstraction Layers
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Custom Interface: IVoiceActivityDetector                 │
+│   DetectSpeechAsync() → IAsyncEnumerable<SpeechSegment>  │
+├─────────────────────────────────────────────────────────┤
+│ ML.NET: ITransformer / IEstimator<T>                     │
+│   OnnxVadTransformer — composable via .Fit() / .Transform()
+│   Enables pipeline composition with other transforms     │
+├─────────────────────────────────────────────────────────┤
+│ ONNX Runtime: InferenceSession                           │
+│   Silero VAD model (stateful LSTM, ~2 MB)               │
+├─────────────────────────────────────────────────────────┤
+│ Audio Primitives (MLNet.Audio.Core)                      │
+│   AudioData, AudioIO (WAV I/O, resampling)              │
+└─────────────────────────────────────────────────────────┘
+```
+
+Note: VAD doesn't use MEAI interfaces (no `IVoiceActivityDetector` in Microsoft.Extensions.AI yet), MEDI, or ML.Tokenizers. The `IVoiceActivityDetector` is a library-specific interface — a natural candidate for future MEAI standardization.
+
 ### The Model: Silero VAD
 
 [Silero VAD](https://github.com/snakers4/silero-vad) is purpose-built for voice activity detection:

--- a/samples/VoiceActivityDetection/README.md
+++ b/samples/VoiceActivityDetection/README.md
@@ -44,6 +44,33 @@ Classification labels a *whole clip*; VAD finds *time segments within* a clip.
 - **Real-time communication:** Mute detection, echo cancellation triggers, bandwidth optimization (don't transmit silence).
 - **Podcast/video editing:** Automatically trim dead air, detect pauses for chapter markers, identify segment boundaries.
 
+### Why VAD Is a Critical Preprocessing Step
+
+VAD is rarely the end goal — it's the **first stage** in larger audio processing pipelines:
+
+| Use Case | How VAD Helps |
+|----------|---------------|
+| **ASR Preprocessing** | Skip silence, reduce Whisper processing time by 30-60% |
+| **Meeting Analysis** | Identify who spoke when (combined with speaker diarization) |
+| **Real-time Communication** | Mute detection, bandwidth optimization, echo cancellation |
+| **Podcast/Video Editing** | Auto-trim silence, find content boundaries |
+| **Security/Surveillance** | Trigger recording only when speech is detected |
+| **Accessibility** | Alert deaf users when someone starts speaking |
+
+In this library, you could compose VAD with ASR:
+
+```csharp
+// Step 1: Detect speech segments
+var segments = vadTransformer.DetectSpeech(audio);
+
+// Step 2: Transcribe only the speech segments (skip silence)
+foreach (var segment in segments)
+{
+    var speechAudio = audio.Slice(segment.Start, segment.End);
+    var text = whisperTransformer.Transcribe(speechAudio);
+}
+```
+
 ### How It Works: Frame-by-Frame Scoring
 
 VAD processes audio through a **sliding window** pipeline:
@@ -276,6 +303,40 @@ Compare with classification output (a single label + score for the entire clip) 
 3. **VAD is a critical preprocessing step for ASR pipelines.** Running Whisper on an entire meeting recording is wasteful and error-prone. VAD identifies the speech segments first, then only those segments are sent for transcription — saving compute and improving accuracy.
 
 4. **The `IVoiceActivityDetector` interface is custom to this library.** Unlike embeddings (`IEmbeddingGenerator`), speech-to-text (`ISpeechToTextClient`), or text-to-speech (`ITextToSpeechClient`), there is no Microsoft.Extensions.AI abstraction for voice activity detection. The `IVoiceActivityDetector` interface provides a streaming-first API with `IAsyncEnumerable<SpeechSegment>`.
+
+## Troubleshooting
+
+### "Model not found" — synthetic demo runs instead
+
+This is expected behavior. Without a Silero VAD model, the sample generates synthetic audio and demonstrates what VAD would detect. To run with real detection:
+
+```bash
+huggingface-cli download snakers4/silero-vad --include "*.onnx" --local-dir models/silero-vad
+```
+
+The model is tiny (~2 MB) — one of the smallest ONNX models you'll use.
+
+### No speech segments detected
+
+- **Threshold too high**: Default is 0.5. Try lowering to 0.3 for quieter speech: `options.Threshold = 0.3f`
+- **MinSpeechDuration too long**: Default is 250ms. Very short utterances ("yes", "no") may be filtered out. Try `options.MinSpeechDuration = TimeSpan.FromMilliseconds(100)`
+- **Audio is too quiet**: Normalize audio to [-1.0, 1.0] range before processing
+- **Wrong sample rate**: Silero VAD expects 16kHz. The transformer auto-resamples, but extremely low sample rate audio (<8kHz) may lose speech information
+
+### Too many speech segments (over-segmentation)
+
+- **MinSilenceDuration too short**: Default is 100ms. Increase to 300-500ms to merge segments separated by brief pauses: `options.MinSilenceDuration = TimeSpan.FromMilliseconds(300)`
+- **SpeechPad too small**: Default is 30ms. Increase padding to merge nearby segments: `options.SpeechPad = TimeSpan.FromMilliseconds(100)`
+- **Threshold too low**: Raise from 0.5 to 0.6-0.7 to be more selective about what counts as speech
+
+### Understanding the LSTM state
+
+Silero VAD is a **stateful model** — it carries hidden state (`h`, `c` tensors) between frames. This means:
+
+- Processing order matters — don't shuffle audio frames
+- The model "remembers" recent context, improving detection at speech/silence boundaries
+- Reset state between unrelated audio files (the transformer handles this automatically)
+- This is why VAD uses 512-sample windows (32ms at 16kHz) — small enough for real-time, large enough for the LSTM to be effective
 
 ## Going Further
 

--- a/samples/VoiceActivityDetection/README.md
+++ b/samples/VoiceActivityDetection/README.md
@@ -66,7 +66,10 @@ var segments = vadTransformer.DetectSpeech(audio);
 // Step 2: Transcribe only the speech segments (skip silence)
 foreach (var segment in segments)
 {
-    var speechAudio = audio.Slice(segment.Start, segment.End);
+    // Convert segment timestamps to sample indices
+    var startSample = (int)(segment.Start * audio.SampleRate);
+    var endSample = Math.Min((int)(segment.End * audio.SampleRate), audio.Samples.Length);
+    var speechAudio = new AudioData(audio.Samples[startSample..endSample], audio.SampleRate);
     var text = whisperTransformer.Transcribe(speechAudio);
 }
 ```

--- a/samples/WhisperRawOnnx/README.md
+++ b/samples/WhisperRawOnnx/README.md
@@ -70,6 +70,32 @@ WhisperTokenizer                 ← Tokenizer primitive (Layer 0)
 Transcription text / segments
 ```
 
+### Abstraction Layers
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ MEAI: ISpeechToTextClient (optional wrapper)             │
+│   OnnxWhisperSpeechToTextClient — provider-agnostic API  │
+├─────────────────────────────────────────────────────────┤
+│ ML.NET: ITransformer / IEstimator<T>                     │
+│   OnnxWhisperTransformer — composable pipeline           │
+│   Exposes Transcribe() and TranscribeWithTimestamps()    │
+├─────────────────────────────────────────────────────────┤
+│ System.Numerics.Tensors: TensorPrimitives               │
+│   SoftMax (temperature sampling), IndexOfMax (greedy)    │
+│   SIMD-accelerated token selection in decoder loop       │
+├─────────────────────────────────────────────────────────┤
+│ ONNX Runtime: InferenceSession                           │
+│   Encoder session + Decoder session (with KV cache)      │
+├─────────────────────────────────────────────────────────┤
+│ Audio Primitives (MLNet.Audio.Core)                      │
+│   WhisperFeatureExtractor (mel spectrogram)              │
+│   WhisperTokenizer (BPE + 1700 special tokens)           │
+└─────────────────────────────────────────────────────────┘
+```
+
+This is the deepest sample in the repo — it touches every layer from raw audio to decoded text. The `TensorPrimitives` usage is architecturally significant here: the decoder loop calls `TensorPrimitives.SoftMax()` and `TensorPrimitives.IndexOfMax()` on every generated token, making SIMD acceleration a real performance factor.
+
 ### KV Cache Explained
 
 The KV (Key-Value) cache is the single most important optimization for autoregressive generation. Here's why:

--- a/samples/WhisperRawOnnx/README.md
+++ b/samples/WhisperRawOnnx/README.md
@@ -257,20 +257,47 @@ models/whisper-base/
 
 The `decoder_model_merged.onnx` is key — it's a single model that handles both the initial full-computation step and subsequent incremental steps via the `use_cache_branch` input.
 
-### 3. Run
+---
+
+## Running It
+
+### With model files (full transcription)
 
 ```bash
-# With model directory
+cd samples/WhisperRawOnnx
+
+# Default: uses models/whisper-base directory
 dotnet run -- "models/whisper-base"
 
-# With model directory and specific audio file
-dotnet run -- "models/whisper-base" "audio.wav"
+# With a specific audio file
+dotnet run -- "models/whisper-base" "path/to/audio.wav"
+```
 
-# Without models (shows API patterns as fallback)
+### Without model files (pattern demonstration)
+
+```bash
+cd samples/WhisperRawOnnx
 dotnet run
 ```
 
-The sample gracefully handles missing models by displaying the API patterns instead.
+Shows API patterns for all three ASR approaches and generates a synthetic mel spectrogram to demonstrate feature extraction — no model download required.
+
+### Exporting the Model
+
+Raw ONNX Whisper requires encoder and decoder models exported via [Optimum](https://huggingface.co/docs/optimum):
+
+```bash
+pip install optimum[onnxruntime]
+optimum-cli export onnx --model openai/whisper-base models/whisper-base/
+```
+
+This creates:
+| File | Purpose | Size |
+|------|---------|------|
+| `encoder_model.onnx` | Audio features → hidden states | ~90 MB |
+| `decoder_model_merged.onnx` | Autoregressive token generation | ~180 MB |
+| `config.json` | Model configuration | <1 KB |
+| `tokenizer.json` | BPE vocabulary + special tokens | ~2 MB |
 
 ---
 
@@ -365,6 +392,40 @@ var pipeline = mlContext.Transforms.OnnxWhisper(rawOnnxOptions);
 4. **Raw ONNX gives full control but requires understanding the decoder loop.** You manage the KV cache, choose the sampling strategy, and process the token stream. This is more work than ORT GenAI but gives you complete visibility and customizability.
 
 5. **All three ASR approaches are available in this repo.** Provider-agnostic for cloud APIs, ORT GenAI for easy local inference, and raw ONNX for full control — choose based on your needs.
+
+---
+
+## Troubleshooting
+
+### "ONNX model not found" error
+Raw ONNX Whisper requires models exported via Optimum (not the standard HuggingFace format). The model directory must contain both `encoder_model.onnx` and `decoder_model_merged.onnx`.
+
+### Transcription is empty or just special tokens
+- The decoder may be generating only `<|endoftext|>` immediately. This usually means:
+  - Audio is silence or too quiet (try a real speech recording)
+  - The mel spectrogram is all zeros (check audio loading)
+  - Model files are corrupted (re-export with Optimum)
+
+### Transcription contains repeated words
+This is a known issue with greedy decoding in small Whisper models. Try:
+- Use temperature sampling: higher temperature (0.5-0.8) reduces repetition
+- Use a larger model (whisper-small or whisper-medium)
+- The KV cache ensures efficient decoding but doesn't prevent repetition — that's a model behavior
+
+### "KV cache dimension mismatch" or shape errors
+- The `WhisperKvCacheManager` auto-detects dimensions from the ONNX model metadata
+- If you exported with a different tool (not Optimum), the cache tensor names may differ
+- Ensure `decoder_model_merged.onnx` contains both the initial (no-past) and with-past paths
+
+### When should I use this vs ORT GenAI vs cloud API?
+
+| Approach | Use When |
+|----------|----------|
+| **Cloud API** (Azure, OpenAI) | Production; highest accuracy; don't want to manage models |
+| **ORT GenAI** ([WhisperTranscription](../WhisperTranscription/)) | Local inference with simple API; "just works" |
+| **Raw ONNX** (this sample) | Learning how Whisper works; custom sampling strategies; debugging; non-standard models |
+
+This sample is the **educational deep-dive**. If you just want transcription, start with [WhisperTranscription](../WhisperTranscription/).
 
 ---
 

--- a/samples/WhisperTranscription/README.md
+++ b/samples/WhisperTranscription/README.md
@@ -42,6 +42,30 @@ This repository provides **three approaches** to the same ASR task (Whisper spee
 
 **This sample is the sweet spot for most local ASR use cases.** You get local execution (no cloud dependency, no data leaves your machine) with a simple API, without needing to understand Whisper's internal encoder-decoder architecture.
 
+### Abstraction Layers
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ MEAI: ISpeechToTextClient                                │
+│   OnnxSpeechToTextClient — same interface as Azure/OpenAI│
+│   Middleware pipeline: logging, OpenTelemetry, caching   │
+├─────────────────────────────────────────────────────────┤
+│ ML.NET: ITransformer / IEstimator<T>                     │
+│   OnnxSpeechToTextTransformer — composable pipeline      │
+│   mlContext.Transforms.OnnxSpeechToText(options)         │
+├─────────────────────────────────────────────────────────┤
+│ ONNX Runtime GenAI                                       │
+│   Handles encoder → decoder loop → KV cache internally   │
+│   You provide mel features, receive token IDs            │
+├─────────────────────────────────────────────────────────┤
+│ Audio Primitives (MLNet.Audio.Core)                      │
+│   WhisperFeatureExtractor (mel spectrogram)              │
+│   AudioData, AudioIO (WAV I/O, resampling)              │
+└─────────────────────────────────────────────────────────┘
+```
+
+ORT GenAI sits between you and the raw ONNX models, handling the complex decoder loop. Compare with [WhisperRawOnnx](../WhisperRawOnnx/) where YOU manage the decoder loop, KV cache, and token sampling directly.
+
 ### Model Format: ORT GenAI-Specific Export
 
 ORT GenAI requires models in its **own export format**, distinct from a plain ONNX export. The model directory must contain:

--- a/samples/WhisperTranscription/README.md
+++ b/samples/WhisperTranscription/README.md
@@ -264,6 +264,60 @@ When no test WAV file is available, the sample generates a 3-second 440Hz sine w
 
 5. **This lives in a separate package (`MLNet.ASR.OnnxGenAI`) to isolate native dependencies.** The ORT GenAI native libraries are large (~100–400MB depending on platform). By putting this in its own package, applications that use cloud ASR or raw ONNX don't pay the size cost.
 
+## Troubleshooting
+
+### "Model not found" — API patterns shown instead
+This is expected behavior. Without a Whisper model in ORT GenAI format, the sample demonstrates API patterns. To run with real transcription:
+
+```bash
+# Option 1: Export with Olive (recommended for ORT GenAI)
+pip install olive-ai
+olive convert --model openai/whisper-base --provider onnxruntime-genai --output models/whisper-base
+
+# Option 2: Export with Optimum
+pip install optimum[onnxruntime]
+optimum-cli export onnx --model openai/whisper-base --task automatic-speech-recognition models/whisper-base/
+```
+
+### Model format confusion: ORT GenAI vs Raw ONNX
+ORT GenAI requires a **`genai_config.json`** file alongside the ONNX models. This is different from the raw ONNX format used by the [WhisperRawOnnx](../WhisperRawOnnx/) sample:
+
+| Format | Config File | Used By | Export Tool |
+|--------|-------------|---------|-------------|
+| ORT GenAI | `genai_config.json` | This sample (`WhisperTranscription`) | Olive |
+| Raw ONNX | `config.json` | [WhisperRawOnnx](../WhisperRawOnnx/) | Optimum |
+
+If you have raw ONNX models but no `genai_config.json`, use the [WhisperRawOnnx](../WhisperRawOnnx/) sample instead.
+
+### ORT GenAI native library not found
+The `MLNet.ASR.OnnxGenAI` package depends on `Microsoft.ML.OnnxRuntimeGenAI.Managed` — but you need to add the **native runtime** package for your platform:
+
+```xml
+<!-- CPU -->
+<PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI" Version="0.12.1" />
+
+<!-- CUDA (NVIDIA GPU) -->
+<PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Version="0.12.1" />
+
+<!-- DirectML (Windows GPU) -->
+<PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Version="0.12.1" />
+```
+
+### Transcription quality issues
+- **Whisper-base** (~74M params) is good for demos but not production. For better accuracy, use `whisper-small` (244M) or `whisper-medium` (769M)
+- Audio should be 16kHz mono PCM for best results (the library auto-resamples)
+- Whisper works best with 30-second audio chunks — very long audio may need chunking
+
+### When should I use this vs Raw ONNX vs cloud API?
+
+| Approach | Convenience | Control | Dependencies |
+|----------|-------------|---------|--------------|
+| **Cloud API** | ⭐⭐⭐ | ⭐ | API key only |
+| **ORT GenAI** (this sample) | ⭐⭐ | ⭐⭐ | ORT GenAI native lib + model |
+| **Raw ONNX** | ⭐ | ⭐⭐⭐ | OnnxRuntime + exported model |
+
+**This sample is the sweet spot** — more control than a cloud API, but the ORT GenAI runtime handles the complex decoder loop and KV cache management for you.
+
 ## Going Further
 
 | To... | See... |


### PR DESCRIPTION
## Summary

Comprehensive documentation improvement across all 9 sample READMEs (+504 lines).

### KittenTTS (major overhaul)
- Updated pipeline diagram to reflect MEDI/ML.Tokenizers refactor from PR #18
- New section: Understanding Phonemes and IPA
- New section: How the Abstraction Layers Compose (4-layer diagram)
- Updated Going Further with links to new MEDI/Tokenizer source

### All 9 Samples
- Added Troubleshooting sections to 7 samples that were missing them
- Added architecture layer diagrams
- Strengthened real-world framing with use cases and comparison tables

### Specific Fixes
- SpeechToText: Added missing Prerequisites section
- WhisperRawOnnx: Added proper Running It section
- TextToSpeech: Added SpeechT5 vs KittenTTS comparison table
- VoiceActivityDetection: Added VAD+ASR composition example
- WhisperTranscription: Added ORT GenAI format guide

Documentation only - no code changes.
